### PR TITLE
fix(product): resolve case-insensitive search and empty keyword issues

### DIFF
--- a/src/main/java/com/ai_marketing_msg_be/common/dto/PageResponse.java
+++ b/src/main/java/com/ai_marketing_msg_be/common/dto/PageResponse.java
@@ -29,4 +29,14 @@ public class PageResponse<T> {
                 .totalPages(page.getTotalPages())
                 .build();
     }
+
+    public static <T> PageResponse<T> empty() {
+        return PageResponse.<T>builder()
+                .content(List.of())
+                .page(0)
+                .size(0)
+                .totalElements(0L)
+                .totalPages(0)
+                .build();
+    }
 }

--- a/src/main/java/com/ai_marketing_msg_be/domain/product/controller/ProductController.java
+++ b/src/main/java/com/ai_marketing_msg_be/domain/product/controller/ProductController.java
@@ -144,8 +144,16 @@ public class ProductController {
             HttpServletRequest request) {
 
         log.info("GET /products/search?name={} - searching for: {}", name, name);
+
+        // 빈 문자열이나 공백만 있는 경우 빈 결과 반환
+        if (name == null || name.trim().isEmpty()) {
+            log.warn("Empty search keyword provided, returning empty result");
+            PageResponse<ProductDto> emptyResponse = PageResponse.empty();
+            return ResponseEntity.ok(ApiResponse.ok(emptyResponse, request.getRequestURI()));
+        }
+
         Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
-        PageResponse<ProductDto> response = productService.searchProductsByName(name, pageable);
+        PageResponse<ProductDto> response = productService.searchProductsByName(name.trim(), pageable);
 
         return ResponseEntity.ok(ApiResponse.ok(response, request.getRequestURI()));
     }

--- a/src/main/java/com/ai_marketing_msg_be/domain/product/repository/ProductRepository.java
+++ b/src/main/java/com/ai_marketing_msg_be/domain/product/repository/ProductRepository.java
@@ -35,9 +35,10 @@ public interface ProductRepository extends JpaRepository<Product, Long> {
     Page<Product> findByStockStatus(StockStatus stockStatus, Pageable pageable);
 
     /**
-     * 상품명으로 검색 (부분 일치)
+     * 상품명으로 검색 (부분 일치, 대소문자 무시)
      */
-    Page<Product> findByNameContaining(String name, Pageable pageable);
+    @Query("SELECT p FROM Product p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))")
+    Page<Product> findByNameContaining(@Param("name") String name, Pageable pageable);
 
     /**
      * 가격 범위로 검색


### PR DESCRIPTION
- JPQL 쿼리에 LOWER() 함수 적용하여 대소문자 무시 검색 처리
- ProductController에 빈 문자열 검증 추가
- 결과가 없을 때 사용할 PageResponse.empty() 메서드 구현
- 검색 키워드의 공백 제거(trim) 처리

Closes #20

## 📋 작업 내용

### 버그 설명
상품 검색 API(`/products/search`)에서 다음과 같은 문제가 발생했습니다:
1. 빈 문자열이나 공백으로 검색 시 전체 상품이 반환됨
2. 특정 키워드 검색 시 대소문자 구분 및 일관성 없는 검색 결과 발생

### 주요 변경사항

#### 1. ProductRepository.java (Line 40-41)
JPQL 쿼리에 `LOWER()` 함수 적용하여 대소문자 무시 검색 구현

```java
@Query("SELECT p FROM Product p WHERE LOWER(p.name) LIKE LOWER(CONCAT('%', :name, '%'))")
Page<Product> findByNameContaining(@Param("name") String name, Pageable pageable);
```

**변경 이유:**
- 기존 Spring Data JPA의 자동 생성 메서드는 대소문자를 구분함
- `LOWER()` 함수를 사용하여 검색어와 데이터베이스 값을 모두 소문자로 변환하여 비교

#### 2. ProductController.java (Line 148-156)
빈 문자열 및 공백 검증 로직 추가

```java
// 빈 문자열이나 공백만 있는 경우 빈 결과 반환
if (name == null || name.trim().isEmpty()) {
    log.warn("Empty search keyword provided, returning empty result");
    PageResponse<ProductDto> emptyResponse = PageResponse.empty();
    return ResponseEntity.ok(ApiResponse.ok(emptyResponse, request.getRequestURI()));
}

Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
PageResponse<ProductDto> response = productService.searchProductsByName(name.trim(), pageable);
```

**변경 이유:**
- 빈 문자열 검색 시 전체 상품이 반환되는 문제 해결
- `trim()`을 통해 앞뒤 공백 제거
- 유효하지 않은 검색어에 대해 명확한 빈 결과 반환

#### 3. PageResponse.java (Line 33-41)
빈 결과를 위한 `empty()` 정적 팩토리 메서드 추가

```java
public static <T> PageResponse<T> empty() {
    return PageResponse.<T>builder()
            .content(List.of())
            .page(0)
            .size(0)
            .totalElements(0L)
            .totalPages(0)
            .build();
}
```

**변경 이유:**
- 빈 결과를 일관되게 반환하기 위한 유틸리티 메서드
- 코드 재사용성 향상
- null 반환 방지

### 수정된 파일
- `src/main/java/com/ai_marketing_msg_be/domain/product/repository/ProductRepository.java`
- `src/main/java/com/ai_marketing_msg_be/domain/product/controller/ProductController.java`
- `src/main/java/com/ai_marketing_msg_be/common/dto/PageResponse.java`

## 🧪 테스트 체크리스트
- [x] 로컬 환경에서 정상 동작 확인
- [x] API 테스트 완료
  - 대소문자 무시 검색: "기가", "GIGA", "Giga" 모두 동일한 결과 반환
  - 빈 문자열 검색: 빈 결과 반환 확인
  - 공백 검색: 빈 결과 반환 확인
  - 한글 키워드 검색: 정상 작동 확인
- [ ] 단위 테스트 작성/수정 (테스트 코드는 이전에 제거됨)
- [ ] 통합 테스트 확인 (테스트 코드는 이전에 제거됨)
- [x] 기존 기능에 영향 없음을 확인

## 📸 테스트 결과

### 수정 전
```
GET /products/search?name=기가
→ 검색 결과 없음 또는 불일치

GET /products/search?name=GIGA
→ 다른 검색 결과

GET /products/search?name=
→ 전체 상품 반환 (잘못된 동작)

GET /products/search?name=
→ 전체 상품 반환 (잘못된 동작)
```

### 수정 후
```
GET /products/search?name=기가
GET /products/search?name=GIGA
GET /products/search?name=Giga
→ 모두 동일한 검색 결과 반환 (대소문자 무시)

GET /products/search?name=
GET /products/search?name=
→ 빈 결과 반환 (정상 동작)
{
  "content": [],
  "page": 0,
  "size": 0,
  "totalElements": 0,
  "totalPages": 0
}
```

## 📝 리뷰 요청사항
- JPQL 쿼리의 `LOWER()` 함수 사용이 성능에 미치는 영향 검토 부탁드립니다
- 빈 문자열 처리 로직이 다른 API와 일관성이 있는지 확인 부탁드립니다
- 향후 Full-Text Search 도입 시기에 대한 의견 부탁드립니다

## ⚠️ 주의사항
- 대소문자 무시 검색을 위해 `LOWER()` 함수를 사용하므로, 대용량 데이터에서는 인덱스 활용이 제한될 수 있습니다
- 추후 성능 이슈 발생 시 다음 옵션 검토 필요:
  1. MySQL Full-Text Search 인덱스 활용
  2. Elasticsearch 등 검색 엔진 도입
  3. 검색어를 저장 시점에 소문자로 정규화

## 🚀 배포 시 필요한 작업
- [x] DB 마이그레이션 (불필요)
- [x] 환경 변수 추가/수정 (불필요)
- [x] 외부 API 설정 (불필요)
- [x] 기타: 없음

## 📊 커밋 정보
- **브랜치**: `fix/20-product-search-bug`
- **커밋 해시**: `ec48b8e`
- **커밋 메시지**:
  ```
  fix(product): resolve case-insensitive search and empty keyword issues

  - JPQL 쿼리에 LOWER() 함수 적용하여 대소문자 무시 검색 처리
  - ProductController에 빈 문자열 검증 추가
  - 결과가 없을 때 사용할 PageResponse.empty() 메서드 구현
  - 검색 키워드의 공백 제거(trim) 처리

  Closes #20
  ```

## 🔍 코드 리뷰 포인트

### 1. Repository Layer
- JPQL에서 `LOWER()` 함수 사용이 적절한가?
- 인덱스 활용 가능 여부 확인

### 2. Controller Layer
- 빈 문자열 검증 위치가 적절한가?
- 로깅 레벨이 적절한가? (현재 WARN)

### 3. DTO Layer
- `PageResponse.empty()` 메서드의 반환값이 적절한가?
- 다른 곳에서도 재사용 가능한가?

---

### ✅ PR 작성자 체크리스트
- [x] 브랜치명이 컨벤션에 맞게 작성되었습니다 (`fix/20-product-search-bug`)
- [x] 커밋 메시지가 AngularJS 컨벤션을 따릅니다
- [x] 코드에 적절한 주석이 추가되었습니다
- [x] 불필요한 코드나 주석이 제거되었습니다
- [ ] 테스트 코드가 작성되었습니다 (이전에 제거됨)
- [x] API 문서(Swagger)가 업데이트되었습니다 (기존 API 명세 유지)

---

## 📌 참고 문서
- GitHub Issue: https://github.com/KTCS-MIXOLOGY/AI_MARKETING_MSG_BE/issues/20
- API 엔드포인트: `GET /products/search?name={keyword}`
- 관련 파일:
  - [ProductRepository.java](src/main/java/com/ai_marketing_msg_be/domain/product/repository/ProductRepository.java)
  - [ProductController.java](src/main/java/com/ai_marketing_msg_be/domain/product/controller/ProductController.java)
  - [PageResponse.java](src/main/java/com/ai_marketing_msg_be/common/dto/PageResponse.java)
