### PR TITLE
[FEAT] 회원가입 API에서 department 필드 누락 수정 

### DIFF
--- a/src/main/java/com/ai_marketing_msg_be/auth/dto/AuthRegisterRequest.java
+++ b/src/main/java/com/ai_marketing_msg_be/auth/dto/AuthRegisterRequest.java
@@ -36,4 +36,7 @@ public class AuthRegisterRequest {
 
     @NotBlank(message = "Role is required")
     private String role;
+
+    @NotBlank(message = "Department is required")
+    private String department;
 }

--- a/src/main/java/com/ai_marketing_msg_be/auth/dto/AuthRegisterResponse.java
+++ b/src/main/java/com/ai_marketing_msg_be/auth/dto/AuthRegisterResponse.java
@@ -13,6 +13,7 @@ public class AuthRegisterResponse {
     private String username;
     private String email;
     private String role;
+    private String department;
     private String status;
     private String createdAt;
     private String message;
@@ -22,6 +23,7 @@ public class AuthRegisterResponse {
             String username,
             String email,
             String role,
+            String department,
             String status,
             String createdAt
     ) {
@@ -30,6 +32,7 @@ public class AuthRegisterResponse {
                 .username(username)
                 .email(email)
                 .role(role)
+                .department(department)
                 .status(status)
                 .createdAt(createdAt)
                 .message("회원가입이 완료되었습니다. 관리자 승인 후 로그인 가능합니다.")

--- a/src/main/java/com/ai_marketing_msg_be/auth/service/AuthService.java
+++ b/src/main/java/com/ai_marketing_msg_be/auth/service/AuthService.java
@@ -91,6 +91,7 @@ public class AuthService {
                 .name(request.getName())
                 .phone(request.getPhone())
                 .role(UserRole.EXECUTOR)
+                .department(request.getDepartment())
                 .status(UserStatus.PENDING)
                 .build();
 
@@ -104,6 +105,7 @@ public class AuthService {
                 savedUser.getUsername(),
                 savedUser.getEmail(),
                 savedUser.getRole().name(),
+                savedUser.getDepartment(),
                 savedUser.getStatus().name(),
                 savedUser.getCreatedAt().toString()
         );


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 링크해주세요 -->
Closes #23 

## 📋 작업 내용
<!-- 이 PR에서 수행한 작업을 설명해주세요 -->
- 회원가입 API 명세서에 누락된 "department" 필드에 대하여 회원가입 관련 dto (AuthRegisterRequest, AuthRegisterResponse)에 "department" 필드 추가 
- 회원가입 비즈니스 로직 (AuthService - register()) 에 부서 정보 저장 로직 및 반환 로직 추가 

### 주요 변경사항
- `AuthRegisterRequest`: department 필드 추가 
- `AuthRegisterResponse`: department 필드 추가
- `AuthService`: register() 메서드 로직 추가 

## 🧪 테스트 체크리스트
<!-- 수행한 테스트 항목을 체크해주세요 -->
- [x] 로컬 환경에서 정상 동작 확인
- [x] API 테스트 완료
- [ ] 단위 테스트 작성/수정
- [ ] 통합 테스트 확인
- [x] 기존 기능에 영향 없음을 확인

## 📸 스크린샷 
<!-- API 테스트 결과, Swagger UI, 로그 등 -->
<img width="702" height="707" alt="image" src="https://github.com/user-attachments/assets/b4162d7e-7a99-4063-8c64-30a6df13e3f6" />

## 📝 리뷰 요청사항
<!-- 특별히 리뷰어가 집중해서 봐주었으면 하는 부분 -->
- DTO에 추가된 `department` 필드의 validation 규칙이 적절한지 확인 부탁드립니다
- 회원가입 시 부서 정보가 필수인지 선택인지에 대한 검토 필요 (`@NotBlank` vs `@Nullable`)
- 기존 회원 조회 API의 응답 스펙과 일관성이 유지되는지 확인 부탁드립니다
- API 명세서 문서와 실제 구현이 정확히 일치하는지 최종 검토 부탁드립니다

## ⚠️ 주의사항
<!-- 배포 시 주의할 점, 환경 변수 추가 여부 등 -->
- **기존 회원 데이터 처리**: 이 수정 전에 가입된 회원들은 `department` 필드가 `null`로 저장되어 있습니다
  - 회원 목록/상세 조회 시 `null` 값이 반환될 수 있으니, 프론트엔드에서 null 처리 필요
  - 필요시 기존 회원의 부서 정보를 일괄 업데이트하는 별도 작업 고려 필요
- DB 스키마 변경은 없으므로 별도 마이그레이션 불필요
- API 명세서가 함께 업데이트되었으므로 프론트엔드 팀과 변경사항 공유 필요

## 🚀 배포 시 필요한 작업
<!-- 배포 전에 수행해야 할 작업이 있다면 작성해주세요 -->
- [ ] ~~DB 마이그레이션~~ (스키마 변경 없음)
- [ ] ~~환경 변수 추가/수정~~ (해당 없음)
- [ ] ~~외부 API 설정~~ (해당 없음)
- [x] API 명세서 문서 배포/공유 (프론트엔드 팀)
- [ ] 기타: 기존 회원 데이터의 department 일괄 업데이트 필요 시 별도 스크립트 작성 검토

---

### ✅ PR 작성자 체크리스트
- [x] 브랜치명이 컨벤션에 맞게 작성되었습니다 (`feature/이슈번호-기능명`)
- [x] 커밋 메시지가 AngularJS 컨벤션을 따릅니다
- [x] 코드에 적절한 주석이 추가되었습니다
- [x] 불필요한 코드나 주석이 제거되었습니다
- [ ] 테스트 코드가 작성되었습니다 (해당되는 경우)
- [x] API 문서(Swagger)가 업데이트되었습니다 (해당되는 경우)