### PR TITLE
[FIX] 회원가입 API ADMIN 계정 생성 누락 문제 해결

### DIFF
--- a/src/main/java/com/ai_marketing_msg_be/auth/dto/AuthRegisterResponse.java
+++ b/src/main/java/com/ai_marketing_msg_be/auth/dto/AuthRegisterResponse.java
@@ -1,5 +1,7 @@
 package com.ai_marketing_msg_be.auth.dto;
 
+import static com.ai_marketing_msg_be.domain.user.entity.UserRole.ADMIN;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +29,9 @@ public class AuthRegisterResponse {
             String status,
             String createdAt
     ) {
+        String message = "회원가입이 완료되었습니다.";
+        String executorMessage = "관리자 승인 후 로그인 가능합니다.";
+
         return AuthRegisterResponse.builder()
                 .userId(userId)
                 .username(username)
@@ -35,7 +40,7 @@ public class AuthRegisterResponse {
                 .department(department)
                 .status(status)
                 .createdAt(createdAt)
-                .message("회원가입이 완료되었습니다. 관리자 승인 후 로그인 가능합니다.")
+                .message(message + (role.equals(ADMIN.toString()) ? "" : executorMessage))
                 .build();
     }
 }

--- a/src/main/java/com/ai_marketing_msg_be/auth/service/AuthService.java
+++ b/src/main/java/com/ai_marketing_msg_be/auth/service/AuthService.java
@@ -83,16 +83,16 @@ public class AuthService {
         log.debug("Validation passed. Encoding password for username: {}", request.getUsername());
 
         String encodedPassword = passwordEncoder.encode(request.getPassword());
-
+        UserRole role = UserRole.valueOf(request.getRole());
         User user = User.builder()
                 .username(request.getUsername())
                 .password(encodedPassword)
                 .email(request.getEmail())
                 .name(request.getName())
                 .phone(request.getPhone())
-                .role(UserRole.EXECUTOR)
+                .role(role)
                 .department(request.getDepartment())
-                .status(UserStatus.PENDING)
+                .status(role == UserRole.EXECUTOR ? UserStatus.PENDING : UserStatus.APPROVED)
                 .build();
 
         User savedUser = userRepository.save(user);


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이 PR이 해결하는 이슈를 링크해주세요 -->
Closes #27 

## 📋 작업 내용
<!-- 이 PR에서 수행한 작업을 설명해주세요 -->
기존 회원가입시 실행자만 생성 가능하도록 한 점을 관리자 계정도 생성 가능하도록 수정

### 주요 변경사항
- AuthService의 register() 메서드 : User 객체 생성시 role 설정 및 status 설정 로직 수정 
- AuthRegisterResponse 응답에서 message 형식도 role에 따라 차등 생성하도록 수정 

## 🧪 테스트 체크리스트
<!-- 수행한 테스트 항목을 체크해주세요 -->
- [x] 로컬 환경에서 정상 동작 확인
- [x] API 테스트 완료
- [ ] 단위 테스트 작성/수정
- [ ] 통합 테스트 확인
- [x] 기존 기능에 영향 없음을 확인

## 📸 스크린샷 (선택사항)
<!-- API 테스트 결과, Swagger UI, 로그 등 -->
### 관리자 회원가입 테스트 
<img width="527" height="756" alt="image" src="https://github.com/user-attachments/assets/6bcfbfe3-35ed-43ac-a29b-3b3d17eade74" />

### 관리자 회원가입 후 로그인 테스트
<img width="787" height="776" alt="image" src="https://github.com/user-attachments/assets/5d914ccb-2347-4914-9dbc-d0cad498c07a" />


---

### ✅ PR 작성자 체크리스트
- [x] 브랜치명이 컨벤션에 맞게 작성되었습니다 (`feature/이슈번호-기능명`)
- [x] 커밋 메시지가 AngularJS 컨벤션을 따릅니다
- [ ] 코드에 적절한 주석이 추가되었습니다
- [ ] 불필요한 코드나 주석이 제거되었습니다
- [ ] 테스트 코드가 작성되었습니다 (해당되는 경우)
- [x] API 문서(Swagger)가 업데이트되었습니다 (해당되는 경우)